### PR TITLE
update hms push library version to support android:exported flag using android 12 as target

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -62,6 +62,6 @@ dependencies {
     implementation project(':glide-debug')
     implementation project(':volley-debug')
     implementation 'com.huawei.agconnect:agconnect-core:1.3.1.300'
-    implementation 'com.huawei.hms:push:5.3.0.304'
+    implementation 'com.huawei.hms:push:6.1.0.300'
     implementation 'com.google.code.gson:gson:2.8.5'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,11 +3,11 @@ apply plugin: 'com.android.application'
 // apply plugin: "com.huawei.agconnect"
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
     defaultConfig {
         applicationId "com.dimelo.sampleapp"
         minSdkVersion 17
-        targetSdkVersion 30
+        targetSdkVersion 31
         versionCode 6
         versionName "1.1"
     }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -34,7 +34,9 @@
 
         <!-- Push Notifs -->
         <!--FCM configuration-->
-        <service android:name=".MyFirebaseMessagingService">
+        <service
+            android:name=".MyFirebaseMessagingService"
+            android:exported="false">
             <intent-filter>
                 <action android:name="com.google.firebase.MESSAGING_EVENT" />
             </intent-filter>
@@ -53,7 +55,8 @@
         <activity
             android:name=".MainActivity"
             android:label="@string/app_name"
-            android:windowSoftInputMode="adjustResize">
+            android:windowSoftInputMode="adjustResize"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />


### PR DESCRIPTION
- Update hms push library version to support `android:exported` flag using android 12 as target