### PR TITLE
Fix: no polling on "/threads" when entering the threads list for the first time. RD-18686

### DIFF
--- a/app/src/main/java/com/dimelo/sampleapp/SlidingTabFragment.java
+++ b/app/src/main/java/com/dimelo/sampleapp/SlidingTabFragment.java
@@ -47,12 +47,24 @@ public class SlidingTabFragment extends Fragment {
 
         // Creating The ViewPagerAdapter and Passing Fragment Manager, Titles fot the Tabs and Number Of Tabs.
         mViewPagerAdapter = new ViewPagerAdapter(getFragmentManager(), tabTitles, iconIds, selectedIconIds);
-//            mViewPagerAdapter = new ViewPagerAdapter(getFragmentManager(), tabTitles, iconIds, selectedIconIds);
 
         // Assigning ViewPager View and setting the adapter
         mViewPager = (ViewPager) view.findViewById(R.id.pager);
         mViewPager.setAdapter(mViewPagerAdapter);
         mViewPager.setOffscreenPageLimit(4);
+
+        mViewPager.addOnPageChangeListener(new ViewPager.OnPageChangeListener() {
+            @Override
+            public void onPageScrolled(int position, float positionOffset, int positionOffsetPixels) {}
+
+            @Override
+            public void onPageSelected(int position) {
+                support.rcFragmentSetUserVisibleHint(position == 2);
+            }
+
+            @Override
+            public void onPageScrollStateChanged(int state) {}
+        });
 
         // Assiging the Sliding Tab Layout View
         SlidingTabLayout mSlidingTabLayout = (SlidingTabLayout) view.findViewById(R.id.sliding_tabs);

--- a/app/src/main/java/com/dimelo/sampleapp/chats/TabSupport.java
+++ b/app/src/main/java/com/dimelo/sampleapp/chats/TabSupport.java
@@ -41,6 +41,7 @@ public class TabSupport extends Fragment implements SampleDimeloTab {
             fragmentTransaction.commit();
         }
 
+        mDimeloChat.setUserVisibleHint(false);
         customize();
     }
 
@@ -65,6 +66,11 @@ public class TabSupport extends Fragment implements SampleDimeloTab {
 
     @Override
     public boolean isHandlingBack() {
+        if (isVisible()) {
+            mDimeloChat.setUserVisibleHint(false);
+            return true;
+        }
+
         return false;
     }
 
@@ -89,5 +95,11 @@ public class TabSupport extends Fragment implements SampleDimeloTab {
         mDimeloChat.onRequestPermissionsResult(requestCode, permissions, grantResults);
     }
 
+    public void rcFragmentSetUserVisibleHint(boolean hint) {
+        if (mDimeloChat == null) {
+            return;
+        }
 
+        mDimeloChat.setUserVisibleHint(hint);
+    }
 }


### PR DESCRIPTION
- Set `setUserVisibleHint()` to `false` for the `mDimeloChat` instance when attached it or when pressing the back button inside the `TabSupport`
- Set `setUserVisibleHint()` to `true` for the `mDimeloChat` instance  when selecting the `TabSupport` otherwise set it to `false`
