### PR TITLE
Fix: rotating the device to landscape while on the telecom tab crashes the app. RD-27298

### DIFF
--- a/app/src/main/java/com/dimelo/sampleapp/SlidingTabFragment.java
+++ b/app/src/main/java/com/dimelo/sampleapp/SlidingTabFragment.java
@@ -59,7 +59,9 @@ public class SlidingTabFragment extends Fragment {
 
             @Override
             public void onPageSelected(int position) {
-                support.rcFragmentSetUserVisibleHint(position == 2);
+                if (support != null) {
+                    support.rcFragmentSetUserVisibleHint(position == 2);
+                }
             }
 
             @Override


### PR DESCRIPTION
- Fix:  rotating the device to landscape while on the telecom tab crashes the app. RD-27298