### PR TITLE
Remove dead code related to the fix on the handling of the "Back" button (the host activity is no longer recreated unnecessarily when the SDK is opened RD-39880)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -74,16 +74,8 @@
         </activity>
 
         <!-- Dimelo SDK Activity -->
-        <activity android:name="com.dimelo.dimelosdk.main.ChatActivity" >
-            <meta-data
-                android:name="android.support.PARENT_ACTIVITY"
-                android:value="com.dimelo.sampleapp.MainActivity" />
-        </activity>
-        <activity android:name="com.dimelo.dimelosdk.main.ThreadsListActivity">
-            <meta-data
-                android:name="android.support.PARENT_ACTIVITY"
-                android:value="com.dimelo.sampleapp.MainActivity" />
-        </activity>
+        <activity android:name="com.dimelo.dimelosdk.main.ChatActivity" />
+        <activity android:name="com.dimelo.dimelosdk.main.ThreadsListActivity" />
 
         <!-- update userId and threading -->
         <activity android:name=".RcConfigurationActivity" />


### PR DESCRIPTION
- Remove dead code related to the fix on the handling of the "Back" button (the host activity is no longer recreated unnecessarily when the SDK is opened RD-39880)